### PR TITLE
feat: make source citations clickable lesson links

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from pydantic import BaseModel
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 import os
 
 from config import config
@@ -43,7 +43,7 @@ class QueryRequest(BaseModel):
 class QueryResponse(BaseModel):
     """Response model for course queries"""
     answer: str
-    sources: List[str]
+    sources: List[Dict[str, Any]]
     session_id: str
 
 class CourseStats(BaseModel):

--- a/backend/search_tools.py
+++ b/backend/search_tools.py
@@ -89,28 +89,33 @@ class CourseSearchTool(Tool):
         """Format search results with course and lesson context"""
         formatted = []
         sources = []  # Track sources for the UI
-        
+
         for doc, meta in zip(results.documents, results.metadata):
             course_title = meta.get('course_title', 'unknown')
             lesson_num = meta.get('lesson_number')
-            
+
             # Build context header
             header = f"[{course_title}"
             if lesson_num is not None:
                 header += f" - Lesson {lesson_num}"
             header += "]"
-            
+
             # Track source for the UI
-            source = course_title
+            source_text = course_title
             if lesson_num is not None:
-                source += f" - Lesson {lesson_num}"
-            sources.append(source)
-            
+                source_text += f" - Lesson {lesson_num}"
+
+            lesson_url = None
+            if lesson_num is not None:
+                lesson_url = self.store.get_lesson_link(course_title, lesson_num)
+
+            sources.append({"text": source_text, "url": lesson_url})
+
             formatted.append(f"{header}\n{doc}")
-        
+
         # Store sources for retrieval
         self.last_sources = sources
-        
+
         return "\n\n".join(formatted)
 
 class ToolManager:

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -122,10 +122,16 @@ function addMessage(content, type, sources = null, isWelcome = false) {
     let html = `<div class="message-content">${displayContent}</div>`;
     
     if (sources && sources.length > 0) {
+        const sourceItems = sources.map(source => {
+            if (source.url) {
+                return `<a href="${source.url}" target="_blank" rel="noopener noreferrer">${escapeHtml(source.text)}</a>`;
+            }
+            return escapeHtml(source.text);
+        });
         html += `
             <details class="sources-collapsible">
                 <summary class="sources-header">Sources</summary>
-                <div class="sources-content">${sources.join(', ')}</div>
+                <div class="sources-content">${sourceItems.join(', ')}</div>
             </details>
         `;
     }


### PR DESCRIPTION
## Summary
- Source citations in the chat UI are now clickable links that open the corresponding lesson video in a new tab
- Lesson URLs are fetched from ChromaDB's `course_catalog` collection via the existing `get_lesson_link()` helper in `VectorStore`
- Sources without a URL fall back to plain text (no broken links)

## Changes
- `backend/search_tools.py` — `_format_results()` now stores sources as `{"text", "url"}` dicts instead of plain strings
- `backend/app.py` — `QueryResponse.sources` type updated from `List[str]` to `List[Dict[str, Any]]`
- `frontend/script.js` — source rendering updated to generate `<a>` tags with `target="_blank"`

## Test plan
- [x] Start server with `./run.sh`
- [x] Ask a question that triggers a course search
- [x] Expand the "Sources" section — citations should appear as clickable links
- [x] Click a link — should open the lesson video URL in a new tab
- [x] Hard refresh (`Cmd+Shift+R`) if sources appear as `[object Object]` (browser cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)