### PR TITLE
style: render source citations as pill tags

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -131,7 +131,7 @@ function addMessage(content, type, sources = null, isWelcome = false) {
         html += `
             <details class="sources-collapsible">
                 <summary class="sources-header">Sources</summary>
-                <div class="sources-content">${sourceItems.join(', ')}</div>
+                <div class="sources-content">${sourceItems.join('')}</div>
             </details>
         `;
     }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -241,8 +241,29 @@ header h1 {
 }
 
 .sources-content {
-    padding: 0 0.5rem 0.25rem 1.5rem;
-    color: var(--text-secondary);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.25rem 0.5rem 0.25rem 1.5rem;
+}
+
+.sources-content a {
+    display: inline-block;
+    padding: 0.2rem 0.6rem;
+    background: rgba(37, 99, 235, 0.15);
+    border: 1px solid rgba(37, 99, 235, 0.4);
+    border-radius: 999px;
+    color: #93c5fd;
+    text-decoration: none;
+    font-size: 0.72rem;
+    white-space: nowrap;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.sources-content a:hover {
+    background: rgba(37, 99, 235, 0.3);
+    border-color: rgba(37, 99, 235, 0.7);
+    color: #bfdbfe;
 }
 
 /* Markdown formatting styles */


### PR DESCRIPTION
## Summary
- Source citations are now displayed as flex-wrapped pill tags instead of comma-separated inline text
- Pills use a blue-tinted background with rounded borders that match the dark theme palette
- Hover state provides subtle visual feedback

## Test plan
- [x] Start server with `./run.sh`
- [x] Ask a question that triggers a course search
- [x] Expand the "Sources" section — citations should appear as pill tags
- [x] Hover over a pill — should brighten slightly
- [x] Click a pill — should open the lesson video in a new tab
- [x] Hard refresh (`Cmd+Shift+R`) if styles don't appear updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)