### PR TITLE
feat: add CourseOutlineTool for structured course outline queries

### DIFF
--- a/backend/ai_generator.py
+++ b/backend/ai_generator.py
@@ -12,10 +12,12 @@ Search Tool Usage:
 - **One search per query maximum**
 - Synthesize search results into accurate, fact-based responses
 - If search yields no results, state this clearly without offering alternatives
+- Use the `get_course_outline` tool for questions about a course's structure, lesson list, or outline
 
 Response Protocol:
 - **General knowledge questions**: Answer using existing knowledge without searching
 - **Course-specific questions**: Search first, then answer
+- **Course outline responses**: Include the course title, course link, and each lesson's number and title
 - **No meta-commentary**:
  - Provide direct answers only — no reasoning process, search explanations, or question-type analysis
  - Do not mention "based on the search results"

--- a/backend/rag_system.py
+++ b/backend/rag_system.py
@@ -4,7 +4,7 @@ from document_processor import DocumentProcessor
 from vector_store import VectorStore
 from ai_generator import AIGenerator
 from session_manager import SessionManager
-from search_tools import ToolManager, CourseSearchTool
+from search_tools import ToolManager, CourseSearchTool, CourseOutlineTool
 from models import Course, Lesson, CourseChunk
 
 class RAGSystem:
@@ -23,6 +23,8 @@ class RAGSystem:
         self.tool_manager = ToolManager()
         self.search_tool = CourseSearchTool(self.vector_store)
         self.tool_manager.register_tool(self.search_tool)
+        self.outline_tool = CourseOutlineTool(self.vector_store)
+        self.tool_manager.register_tool(self.outline_tool)
     
     def add_course_document(self, file_path: str) -> Tuple[Course, int]:
         """

--- a/backend/search_tools.py
+++ b/backend/search_tools.py
@@ -118,6 +118,68 @@ class CourseSearchTool(Tool):
 
         return "\n\n".join(formatted)
 
+class CourseOutlineTool(Tool):
+    """Tool for retrieving course outline from course catalog metadata"""
+
+    def __init__(self, vector_store: VectorStore):
+        self.store = vector_store
+        self.last_sources = []
+
+    def get_tool_definition(self) -> Dict[str, Any]:
+        return {
+            "name": "get_course_outline",
+            "description": "Get the outline of a course: its title, link, and complete lesson list with lesson numbers and titles",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "course_name": {
+                        "type": "string",
+                        "description": "Course title (partial matches work, e.g. 'MCP', 'Introduction')"
+                    }
+                },
+                "required": ["course_name"]
+            }
+        }
+
+    def execute(self, course_name: str) -> str:
+        import json
+
+        # Resolve fuzzy course name to exact title
+        course_title = self.store._resolve_course_name(course_name)
+        if not course_title:
+            return f"No course found matching '{course_name}'."
+
+        # Fetch metadata from catalog
+        try:
+            results = self.store.course_catalog.get(ids=[course_title])
+        except Exception as e:
+            return f"Error retrieving course outline: {e}"
+
+        if not results or not results.get('metadatas') or not results['metadatas']:
+            return f"No metadata found for course '{course_title}'."
+
+        metadata = results['metadatas'][0]
+        title = metadata.get('title', course_title)
+        course_link = metadata.get('course_link', '')
+        lessons_json = metadata.get('lessons_json', '[]')
+        lessons = json.loads(lessons_json)
+
+        # Set source for UI
+        self.last_sources = [{"text": title, "url": course_link or None}]
+
+        # Format output
+        lines = [f"Course: {title}"]
+        if course_link:
+            lines.append(f"Link: {course_link}")
+        lines.append("Lessons:")
+        for lesson in lessons:
+            num = lesson.get('lesson_number')
+            lesson_title = lesson.get('lesson_title', '')
+            lines.append(f"  Lesson {num}: {lesson_title}")
+
+        return "\n".join(lines)
+
+
 class ToolManager:
     """Manages available tools for the AI"""
     


### PR DESCRIPTION
## Summary
- Adds `CourseOutlineTool` (`get_course_outline`) that fetches course title, link, and full lesson list directly from ChromaDB catalog metadata
- Updates system prompt to direct Claude to use the new tool for outline/structure questions and format responses with title, link, and lessons
- Registers the tool in `RAGSystem` alongside the existing `CourseSearchTool`

## Test plan
- [x] Ask "What lessons does the MCP course cover?" → returns structured lesson list with numbers and titles
- [x] Ask "Give me the outline of [course title]" → returns title, link, and all lessons
- [x] Ask "What is RAG?" → answered from general knowledge, no tool call
- [x] Ask "What does lesson 3 cover in [course]?" → still uses `search_course_content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)