### PR TITLE
chore: add .prompts/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ uploads/
 # OS
 .DS_Store
 Thumbs.db
+
+# Local prompts
+.prompts/


### PR DESCRIPTION
## Summary
- Creates a `.prompts/` directory for local working prompts
- Adds `.prompts/` to `.gitignore` so its contents are never tracked

## Test plan
- [ ] Verify `.prompts/` does not appear in `git status` after adding files to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)