### PR TITLE
feat: sequential tool calling with up to 2 rounds in AIGenerator

### DIFF
--- a/backend/ai_generator.py
+++ b/backend/ai_generator.py
@@ -1,15 +1,17 @@
 import anthropic
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
+from config import config
 
 class AIGenerator:
     """Handles interactions with Anthropic's Claude API for generating responses"""
-    
+
     # Static system prompt to avoid rebuilding on each call
     SYSTEM_PROMPT = """ You are an AI assistant specialized in course materials and educational content with access to a comprehensive search tool for course information.
 
 Search Tool Usage:
 - Use the search tool **only** for questions about specific course content or detailed educational materials
-- **One search per query maximum**
+- You may search up to 2 times per query — only when the first search is incomplete or the question has distinct parts requiring different searches
+- Do not repeat the same search twice; use a different or more specific query for the second search
 - Synthesize search results into accurate, fact-based responses
 - If search yields no results, state this clearly without offering alternatives
 - Use the `get_course_outline` tool for questions about a course's structure, lesson list, or outline
@@ -30,108 +32,94 @@ All responses must be:
 4. **Example-supported** - Include relevant examples when they aid understanding
 Provide only the direct answer to what was asked.
 """
-    
+
     def __init__(self, api_key: str, model: str):
         self.client = anthropic.Anthropic(api_key=api_key)
         self.model = model
-        
+
         # Pre-build base API parameters
         self.base_params = {
             "model": self.model,
             "temperature": 0,
             "max_tokens": 800
         }
-    
+
     def generate_response(self, query: str,
                          conversation_history: Optional[str] = None,
                          tools: Optional[List] = None,
                          tool_manager=None) -> str:
         """
         Generate AI response with optional tool usage and conversation context.
-        
+        Supports up to config.MAX_TOOL_ROUNDS sequential tool-call rounds.
+
         Args:
             query: The user's question or request
             conversation_history: Previous messages for context
             tools: Available tools the AI can use
             tool_manager: Manager to execute tools
-            
+
         Returns:
             Generated response as string
         """
-        
+
         # Build system content efficiently - avoid string ops when possible
         system_content = (
             f"{self.SYSTEM_PROMPT}\n\nPrevious conversation:\n{conversation_history}"
-            if conversation_history 
+            if conversation_history
             else self.SYSTEM_PROMPT
         )
-        
-        # Prepare API call parameters efficiently
+
+        # Build initial messages list — mutated in-place each round
+        messages = [{"role": "user", "content": query}]
+
+        # Prepare first API call parameters
         api_params = {
             **self.base_params,
-            "messages": [{"role": "user", "content": query}],
+            "messages": messages,
             "system": system_content
         }
-        
+
         # Add tools if available
         if tools:
             api_params["tools"] = tools
             api_params["tool_choice"] = {"type": "auto"}
-        
-        # Get response from Claude
+
+        # First API call
         response = self.client.messages.create(**api_params)
-        
-        # Handle tool execution if needed
-        if response.stop_reason == "tool_use" and tool_manager:
-            return self._handle_tool_execution(response, api_params, tool_manager)
-        
-        # Return direct response
-        return response.content[0].text
-    
-    def _handle_tool_execution(self, initial_response, base_params: Dict[str, Any], tool_manager):
-        """
-        Handle execution of tool calls and get follow-up response.
-        
-        Args:
-            initial_response: The response containing tool use requests
-            base_params: Base API parameters
-            tool_manager: Manager to execute tools
-            
-        Returns:
-            Final response text after tool execution
-        """
-        # Start with existing messages
-        messages = base_params["messages"].copy()
-        
-        # Add AI's tool use response
-        messages.append({"role": "assistant", "content": initial_response.content})
-        
-        # Execute all tool calls and collect results
-        tool_results = []
-        for content_block in initial_response.content:
-            if content_block.type == "tool_use":
-                tool_result = tool_manager.execute_tool(
-                    content_block.name, 
-                    **content_block.input
-                )
-                
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": content_block.id,
-                    "content": tool_result
-                })
-        
-        # Add tool results as single message
-        if tool_results:
+
+        # Agentic tool loop — up to MAX_TOOL_ROUNDS sequential rounds
+        rounds_used = 0
+        while response.stop_reason == "tool_use" and tool_manager and rounds_used < config.MAX_TOOL_ROUNDS:
+            # Execute all tool calls in this round
+            tool_results = []
+            had_error = False
+            for block in response.content:
+                if block.type == "tool_use":
+                    try:
+                        result = tool_manager.execute_tool(block.name, **block.input)
+                    except Exception as e:
+                        result = f"Tool execution failed: {e}"
+                        had_error = True
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result,
+                    })
+
+            # Append this round's exchange to message history
+            messages.append({"role": "assistant", "content": response.content})
             messages.append({"role": "user", "content": tool_results})
-        
-        # Prepare final API call without tools
-        final_params = {
-            **self.base_params,
-            "messages": messages,
-            "system": base_params["system"]
-        }
-        
-        # Get final response
-        final_response = self.client.messages.create(**final_params)
-        return final_response.content[0].text
+            rounds_used += 1
+
+            # Build next call — include tools only if rounds remain and no error occurred
+            next_params = {**self.base_params, "messages": messages, "system": system_content}
+            if tools and rounds_used < config.MAX_TOOL_ROUNDS and not had_error:
+                next_params["tools"] = tools
+                next_params["tool_choice"] = {"type": "auto"}
+
+            response = self.client.messages.create(**next_params)
+
+            if had_error:
+                break
+
+        return response.content[0].text

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,6 +20,7 @@ class Config:
     CHUNK_OVERLAP: int = 100     # Characters to overlap between chunks
     MAX_RESULTS: int = 5         # Maximum search results to return
     MAX_HISTORY: int = 2         # Number of conversation messages to remember
+    MAX_TOOL_ROUNDS: int = 2     # Maximum sequential tool-call rounds per query
     
     # Database paths
     CHROMA_PATH: str = "./chroma_db"  # ChromaDB storage location

--- a/backend/tests/test_ai_generator.py
+++ b/backend/tests/test_ai_generator.py
@@ -120,7 +120,7 @@ class TestGenerateResponseDirectAnswer:
 
 
 # ---------------------------------------------------------------------------
-# generate_response() — tool_use path
+# generate_response() — single tool-use round
 # ---------------------------------------------------------------------------
 
 class TestGenerateResponseToolUse:
@@ -169,7 +169,8 @@ class TestGenerateResponseToolUse:
         )
         assert mock_client.messages.create.call_count == 2
 
-    def test_second_api_call_excludes_tools(self, generator_with_tool):
+    def test_second_api_call_includes_tools(self, generator_with_tool):
+        """After round 1 there is still a round remaining, so tools must be present in Call 2."""
         gen, mock_client, tool_manager = generator_with_tool
         gen.generate_response(
             query="What is RAG?",
@@ -177,8 +178,8 @@ class TestGenerateResponseToolUse:
             tool_manager=tool_manager,
         )
         second_call_kwargs = mock_client.messages.create.call_args_list[1][1]
-        assert "tools" not in second_call_kwargs
-        assert "tool_choice" not in second_call_kwargs
+        assert "tools" in second_call_kwargs
+        assert "tool_choice" in second_call_kwargs
 
     def test_tool_result_message_has_correct_format(self, generator_with_tool):
         """
@@ -208,3 +209,136 @@ class TestGenerateResponseToolUse:
         assert result_block["type"] == "tool_result"
         assert result_block["tool_use_id"] == "tu_abc123"
         assert result_block["content"] == "RAG stands for Retrieval-Augmented Generation."
+
+
+# ---------------------------------------------------------------------------
+# generate_response() — two sequential tool-use rounds
+# ---------------------------------------------------------------------------
+
+class TestTwoRoundToolUse:
+
+    @pytest.fixture
+    def two_round_setup(self):
+        with patch("ai_generator.anthropic.Anthropic") as MockAnthropic:
+            client_instance = MockAnthropic.return_value
+            r1 = make_tool_use_response(tool_id="tu_round1", tool_input={"query": "outline of course X"})
+            r2 = make_tool_use_response(tool_id="tu_round2", tool_input={"query": "same topic as lesson 4"})
+            final = make_text_response("Here is the complete answer.")
+            client_instance.messages.create.side_effect = [r1, r2, final]
+
+            tool_manager = MagicMock()
+            tool_manager.execute_tool.return_value = "some result"
+
+            gen = AIGenerator(api_key="test-key", model="claude-sonnet-4-6")
+            yield gen, client_instance, tool_manager
+
+    def _run(self, gen, tool_manager):
+        return gen.generate_response(
+            query="Find a course covering the same topic as lesson 4 of course X",
+            tools=[{"name": "search_course_content"}],
+            tool_manager=tool_manager,
+        )
+
+    def test_three_api_calls_made_on_two_rounds(self, two_round_setup):
+        gen, mock_client, tool_manager = two_round_setup
+        self._run(gen, tool_manager)
+        assert mock_client.messages.create.call_count == 3
+
+    def test_tool_manager_called_twice(self, two_round_setup):
+        gen, mock_client, tool_manager = two_round_setup
+        self._run(gen, tool_manager)
+        assert tool_manager.execute_tool.call_count == 2
+
+    def test_final_text_returned_after_two_rounds(self, two_round_setup):
+        gen, mock_client, tool_manager = two_round_setup
+        result = self._run(gen, tool_manager)
+        assert result == "Here is the complete answer."
+
+    def test_second_call_includes_tools(self, two_round_setup):
+        """Call 2 must include tools — round 1 consumed, round 2 still available."""
+        gen, mock_client, tool_manager = two_round_setup
+        self._run(gen, tool_manager)
+        second_call_kwargs = mock_client.messages.create.call_args_list[1][1]
+        assert "tools" in second_call_kwargs
+        assert "tool_choice" in second_call_kwargs
+
+    def test_synthesis_call_excludes_tools(self, two_round_setup):
+        """Call 3 (synthesis after both rounds) must not include tools."""
+        gen, mock_client, tool_manager = two_round_setup
+        self._run(gen, tool_manager)
+        third_call_kwargs = mock_client.messages.create.call_args_list[2][1]
+        assert "tools" not in third_call_kwargs
+        assert "tool_choice" not in third_call_kwargs
+
+    def test_message_history_has_both_rounds(self, two_round_setup):
+        """Call 3 messages must contain the full two-round history:
+        original user msg + assistant r1 + user tool_result r1
+        + assistant r2 + user tool_result r2 = 5 messages total."""
+        gen, mock_client, tool_manager = two_round_setup
+        self._run(gen, tool_manager)
+        third_call_kwargs = mock_client.messages.create.call_args_list[2][1]
+        messages = third_call_kwargs["messages"]
+        assert len(messages) == 5
+
+
+# ---------------------------------------------------------------------------
+# generate_response() — tool execution error handling
+# ---------------------------------------------------------------------------
+
+class TestToolExecutionError:
+
+    @pytest.fixture
+    def error_setup(self):
+        with patch("ai_generator.anthropic.Anthropic") as MockAnthropic:
+            client_instance = MockAnthropic.return_value
+            tool_response = make_tool_use_response()
+            final_response = make_text_response("I was unable to retrieve the information.")
+            client_instance.messages.create.side_effect = [tool_response, final_response]
+
+            tool_manager = MagicMock()
+            tool_manager.execute_tool.side_effect = Exception("DB unavailable")
+
+            gen = AIGenerator(api_key="test-key", model="claude-sonnet-4-6")
+            yield gen, client_instance, tool_manager
+
+    def _run(self, gen, tool_manager):
+        return gen.generate_response(
+            query="What is RAG?",
+            tools=[{"name": "search_course_content"}],
+            tool_manager=tool_manager,
+        )
+
+    def test_returns_string_on_tool_error(self, error_setup):
+        gen, mock_client, tool_manager = error_setup
+        result = self._run(gen, tool_manager)
+        assert isinstance(result, str)
+
+    def test_two_api_calls_on_error(self, error_setup):
+        """Error terminates the loop immediately — no second tool round attempted."""
+        gen, mock_client, tool_manager = error_setup
+        self._run(gen, tool_manager)
+        assert mock_client.messages.create.call_count == 2
+
+    def test_error_result_block_sent_to_claude(self, error_setup):
+        """Even on failure a tool_result block must be sent — the API requires it."""
+        gen, mock_client, tool_manager = error_setup
+        self._run(gen, tool_manager)
+        second_call_kwargs = mock_client.messages.create.call_args_list[1][1]
+        messages = second_call_kwargs["messages"]
+
+        tool_result_messages = [
+            m for m in messages
+            if m.get("role") == "user" and isinstance(m.get("content"), list)
+        ]
+        assert len(tool_result_messages) == 1
+        result_block = tool_result_messages[0]["content"][0]
+        assert result_block["type"] == "tool_result"
+        assert result_block["tool_use_id"] == "tu_abc123"
+
+    def test_synthesis_call_excludes_tools_on_error(self, error_setup):
+        """After an error, the follow-up synthesis call must not include tools."""
+        gen, mock_client, tool_manager = error_setup
+        self._run(gen, tool_manager)
+        second_call_kwargs = mock_client.messages.create.call_args_list[1][1]
+        assert "tools" not in second_call_kwargs
+        assert "tool_choice" not in second_call_kwargs


### PR DESCRIPTION
## Summary
- Replaces the single-round `_handle_tool_execution` method with an inline agentic loop in `generate_response`
- Each tool-call round is a separate API request, allowing Claude to reason about prior results before deciding to search again
- Intermediate calls include tools so Claude can invoke them in round 2; only the final synthesis call strips tools
- Tool execution errors produce a `tool_result` error block (required by the Anthropic API) and exit the loop immediately
- `MAX_TOOL_ROUNDS = 2` added to `config.py` alongside other tuneable constants

## Files changed
- `backend/config.py` — add `MAX_TOOL_ROUNDS: int = 2`
- `backend/ai_generator.py` — loop-based tool handling, updated system prompt
- `backend/tests/test_ai_generator.py` — updated existing test + 2 new test classes (20 tests total, all passing)

## Test plan
- [x] All 20 tests passing: `cd backend && uv run pytest tests/test_ai_generator.py -v`
- [x] Verified locally end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)