### PR TITLE
Add Claude favicon to fix missing favicon 404

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from fastapi.responses import FileResponse, RedirectResponse
 from pydantic import BaseModel
 from typing import Any, Dict, List, Optional
 import os
@@ -52,6 +53,15 @@ class CourseStats(BaseModel):
     course_titles: List[str]
 
 # API Endpoints
+
+@app.get("/favicon.ico", include_in_schema=False)
+async def favicon():
+    """Serve Claude favicon to avoid 404s from direct browser requests"""
+    favicon_path = "../frontend/favicon.svg"
+    if os.path.exists(favicon_path):
+        return FileResponse(favicon_path, media_type="image/svg+xml")
+    return RedirectResponse(url="/favicon.svg")
+
 
 @app.post("/api/query", response_model=QueryResponse)
 async def query_documents(request: QueryRequest):

--- a/frontend/favicon.svg
+++ b/frontend/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="32" height="32">
+  <rect width="100" height="100" rx="22" fill="#CC785C"/>
+  <text x="50" y="72" font-family="Georgia, serif" font-size="68" font-weight="bold" text-anchor="middle" fill="#FFFFFF">C</text>
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Course Materials Assistant</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+    <link rel="shortcut icon" href="/favicon.svg">
     <link rel="stylesheet" href="style.css?v=10">
 </head>
 <body>


### PR DESCRIPTION
Adds a Claude-styled SVG favicon to the app and fixes the 404 error when browsers request `/favicon.ico`.

Changes:
- Add `frontend/favicon.svg` with Claude brand orange rounded square design
- Update `index.html` with favicon link tags
- Add `/favicon.ico` route in `app.py` serving the SVG

Closes #15

Generated with [Claude Code](https://claude.ai/code)